### PR TITLE
불필요한 객체 생성 로직 수정 Resolve #43 

### DIFF
--- a/engine/b/src/main/java/net/crazyinvestor/engine_b/dto/request/BithumbWSSubscribeRequest.java
+++ b/engine/b/src/main/java/net/crazyinvestor/engine_b/dto/request/BithumbWSSubscribeRequest.java
@@ -1,5 +1,6 @@
 package net.crazyinvestor.engine_b.dto.request;
 
+import lombok.Builder;
 import net.crazyinvestor.engine_b.enums.BithumbOpType;
 import net.crazyinvestor.engine_b.enums.BithumbSymbol;
 import net.crazyinvestor.engine_b.enums.BithumbTickTypes;
@@ -8,46 +9,33 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.List;
 
+@Builder
 public final class BithumbWSSubscribeRequest implements Serializable {
     @Serial
     private static final long serialVersionUID = -687691491344005033L;
 
-    private final String opType;
-    private final List<String> symbols;
-    private final List<String> tickTypes;
-
-    public BithumbWSSubscribeRequest(
-            final BithumbOpType opType,
-            final List<BithumbSymbol> symbols,
-            final List<BithumbTickTypes> tickTypes
-    ) {
-        this.opType = opType.getOpType();
-
-        this.symbols = symbols.stream()
-                .map(BithumbSymbol::getType)
-                .toList();
-
-        this.tickTypes = tickTypes.stream()
-                .map(BithumbTickTypes::getTickType)
-                .toList();
-    }
+    private final BithumbOpType opType;
+    private final List<BithumbSymbol> symbols;
+    private final List<BithumbTickTypes> tickTypes;
 
     @Override
     public String toString() {
         List<String> symbolStrList = this.symbols
                 .stream()
+                .map(BithumbSymbol::getType)
                 .distinct() // 중복 제거
                 .map(v -> "\"" + v + "\"") // 문자열 가공
                 .toList(); // 리스트화
 
         List<String> tickTypeStrList = this.tickTypes
                 .stream()
+                .map(BithumbTickTypes::getTickType)
                 .distinct() // 중복 제거
                 .map(v -> "\"" + v + "\"") // 문자열 가공
                 .toList(); // 리스트화
 
         return "{" +
-                "\"type\" : \"" + this.opType + "\"" + ", " +
+                "\"type\" : \"" + this.opType.getOpType() + "\"" + ", " +
                 "\"symbols\" : " + "[" + String.join(", ", symbolStrList) + "]" + ", " +
                 "\"tickTypes\" : " + "[" + String.join(", ", tickTypeStrList) + "]" +
                 "}";

--- a/engine/b/src/test/java/net/crazyinvestor/engine_b/dto/BithumbWSSubscribeRequestTest.java
+++ b/engine/b/src/test/java/net/crazyinvestor/engine_b/dto/BithumbWSSubscribeRequestTest.java
@@ -23,7 +23,12 @@ class BithumbWSSubscribeRequestTest {
         final List<BithumbTickTypes> tickTypes = new LinkedList<>();
         tickTypes.add(BithumbTickTypes.HR_1);
 
-        final BithumbWSSubscribeRequest request = new BithumbWSSubscribeRequest(opType, symbols, tickTypes);
+        final BithumbWSSubscribeRequest request = BithumbWSSubscribeRequest.builder()
+                .opType(opType)
+                .symbols(symbols)
+                .tickTypes(tickTypes)
+                .build();
+
         System.out.println(request);
 
         Assertions.assertEquals(


### PR DESCRIPTION
BithumbWSSubscribeRequest 객체를 Constructor에서 사용 후 버림
 - Constructor에서 BithumbWSSubscribeRequest 객체 생성 (Builder)
 - ToString을 통해 Subscribe 메세지를 생성
 - 생성된 메세지를 String 형태로 저장